### PR TITLE
Feature/driver logger and loki client classes

### DIFF
--- a/conveyor/runtime/driver_logger.py
+++ b/conveyor/runtime/driver_logger.py
@@ -1,20 +1,116 @@
+import httpx
+from httpx import HTTPError, RequestError
+import time
+import logging
+from requests.exceptions import RequestException, HTTPError
+import json
+from nats.aio.client import Client as NATS
+
 
 class LokiClient:
-
     def __init__(self, url: str = "http://localhost:3100"):
         self.url = url
+        self.client = httpx.AsyncClient()  # connection reuse
 
-    def push_log(self, labels: dict, message: str):
-        pass
+    async def push_log(self, labels: dict, message: str) -> None:
+        """
+        Sends the logs to Loki via async HTTP requests for storage or log aggregation.
+
+        :param labels: key-value pairs that describe extra metadata about the log.
+        :param message: The log message to be sent to Loki.
+        :raises HTTPError: If the response from Loki indicates an error (4xx or 5xx).
+        :raises RequestError: If the request to Loki fails due to network issues.
+        :return: None
+        """
+        log_entry = {
+            "streams": [
+                {
+                    "stream": labels,
+                    "values": [
+                        [str(int(time.time() * 1e9)), message]
+                    ]
+                }
+            ]
+        }
+
+        url = f"{self.url}/loki/api/v1/push"
+
+        try:
+            response = await self.client.post(url, json=log_entry, timeout=None)
+            response.raise_for_status()
+            logging.info("Log sent to Loki: %s | Labels: %s", message, labels)
+            logging.debug(
+                "Loki response status code: %s, response: %s, labels: %s",
+                response.status_code,
+                response.text,
+                labels
+            )
+
+        except HTTPError as e:
+            status_code = getattr(e.response, "status_code", "N/A")
+            reason = getattr(e.response, "reason_phrase", "N/A")
+            text = getattr(e.response, "text", "N/A")
+            logging.error(
+                "HTTPError %s: %s | Reason: %s | Response: %s | Labels: %s",
+                status_code,
+                e,
+                reason,
+                text,
+                labels
+            )
+            raise
+
+        except RequestError as e:
+            logging.error("Failed to push log to Loki: %s | Labels: %s", e, labels)
+            raise
+    
+    # TODO: Close the LokiClient (httpx.AsyncClient) when the app is shutting down
+    # This prevents socket leaks and ensures graceful shutdown.
+    # Never close after every log — keep the client open for the app lifetime.
+    async def close(self):
+        await self.client.aclose()
+
+
 
 
 class DriverLogger:
 
-    def __init__(self, driver_name: str, labels: dict, nats_conn):
+    def __init__(self, driver_name: str, labels: dict, nats_conn: NATS, loki_client: LokiClient):
+        """
+        Initializes the DriverLogger with the driver name, labels, NATS connection, and Loki client.
+        """
         self.driver_name = driver_name
         self.labels = labels
         self.nats_conn = nats_conn
-        self.loki_client = LokiClient()
+        self.loki_client = loki_client
 
-    def log(self, labels: dict, message: str):
-        pass
+    async def log(self, labels: dict, message: str)->None:
+
+        """
+        Merges the logger's labels with the provided labels and logs the message to the Loki client and NATS.
+        :param labels: Additional labels to merge with the logger's labels.
+        :param message: The log message to be sent.
+        :raises TypeError: If the labels are not serializable eg a set , function .
+        :raises UnicodeEncodeError: If the message contains non-ASCII characters.
+        """
+
+        merged_labels = {"driver": self.driver_name} 
+        merged_labels.update(self.labels)         
+        merged_labels.update(labels)                 
+        
+       
+        await self.loki_client.push_log(merged_labels,message)
+
+        run_id = merged_labels.get("run_id", "unknown_run")
+
+        timestamp = [str(int(time.time())), message]
+     
+        logging.debug("encoding data to bytes for NATS : %s", timestamp)
+        try:
+            payload = json.dumps(timestamp).encode()
+        except (TypeError, UnicodeEncodeError) as e:
+            logging.error("Failed to encode log payload for NATS: %s | Data: %s", e, timestamp)
+            raise
+
+        logging.info("Publishing log to NATS: %s ", timestamp)
+        await self.nats_conn.publish(f"driver:{self.driver_name}:logs:{run_id}", payload)

--- a/conveyor/runtime/driver_logger.py
+++ b/conveyor/runtime/driver_logger.py
@@ -1,10 +1,10 @@
 import httpx
-from httpx import HTTPError, RequestError
+from httpx import HTTPStatusError, RequestError
 import time
 import logging
-from requests.exceptions import RequestException, HTTPError
 import json
 from nats.aio.client import Client as NATS
+from conveyor.runtime.exceptions import InvalidRunIDException
 
 
 class LokiClient:
@@ -24,12 +24,7 @@ class LokiClient:
         """
         log_entry = {
             "streams": [
-                {
-                    "stream": labels,
-                    "values": [
-                        [str(int(time.time() * 1e9)), message]
-                    ]
-                }
+                {"stream": labels, "values": [[str(int(time.time() * 1e9)), message]]}
             ]
         }
 
@@ -43,10 +38,10 @@ class LokiClient:
                 "Loki response status code: %s, response: %s, labels: %s",
                 response.status_code,
                 response.text,
-                labels
+                labels,
             )
 
-        except HTTPError as e:
+        except HTTPStatusError as e:
             status_code = getattr(e.response, "status_code", "N/A")
             reason = getattr(e.response, "reason_phrase", "N/A")
             text = getattr(e.response, "text", "N/A")
@@ -56,14 +51,14 @@ class LokiClient:
                 e,
                 reason,
                 text,
-                labels
+                labels,
             )
             raise
 
         except RequestError as e:
             logging.error("Failed to push log to Loki: %s | Labels: %s", e, labels)
             raise
-    
+
     # TODO: Close the LokiClient (httpx.AsyncClient) when the app is shutting down
     # This prevents socket leaks and ensures graceful shutdown.
     # Never close after every log — keep the client open for the app lifetime.
@@ -71,11 +66,11 @@ class LokiClient:
         await self.client.aclose()
 
 
-
-
 class DriverLogger:
 
-    def __init__(self, driver_name: str, labels: dict, nats_conn: NATS, loki_client: LokiClient):
+    def __init__(
+        self, driver_name: str, labels: dict, nats_conn: NATS, loki_client: LokiClient
+    ):
         """
         Initializes the DriverLogger with the driver name, labels, NATS connection, and Loki client.
         """
@@ -84,8 +79,7 @@ class DriverLogger:
         self.nats_conn = nats_conn
         self.loki_client = loki_client
 
-    async def log(self, labels: dict, message: str)->None:
-
+    async def log(self, labels: dict, message: str) -> None:
         """
         Merges the logger's labels with the provided labels and logs the message to the Loki client and NATS.
         :param labels: Additional labels to merge with the logger's labels.
@@ -94,23 +88,30 @@ class DriverLogger:
         :raises UnicodeEncodeError: If the message contains non-ASCII characters.
         """
 
-        merged_labels = {"driver": self.driver_name} 
-        merged_labels.update(self.labels)         
-        merged_labels.update(labels)                 
-        
-       
-        await self.loki_client.push_log(merged_labels,message)
+        merged_labels = {"driver": self.driver_name}
+        merged_labels.update(self.labels)
+        merged_labels.update(labels)
 
         run_id = merged_labels.get("run_id", "unknown_run")
 
+        if not run_id or not str(run_id).strip():
+            logging.error("Missing run_id from labels: %s", merged_labels)
+            raise InvalidRunIDException("Missing run_id from labels.")
+
+        await self.loki_client.push_log(merged_labels, message)
+
         timestamp = [str(int(time.time())), message]
-     
+
         logging.debug("encoding data to bytes for NATS : %s", timestamp)
         try:
             payload = json.dumps(timestamp).encode()
         except (TypeError, UnicodeEncodeError) as e:
-            logging.error("Failed to encode log payload for NATS: %s | Data: %s", e, timestamp)
+            logging.error(
+                "Failed to encode log payload for NATS: %s | Data: %s", e, timestamp
+            )
             raise
 
         logging.info("Publishing log to NATS: %s ", timestamp)
-        await self.nats_conn.publish(f"driver:{self.driver_name}:logs:{run_id}", payload)
+        await self.nats_conn.publish(
+            f"driver:{self.driver_name}:logs:{run_id}", payload
+        )

--- a/conveyor/runtime/exceptions.py
+++ b/conveyor/runtime/exceptions.py
@@ -1,0 +1,16 @@
+class DriverRuntimeException(Exception):
+    """
+    Base class for all exceptions raised by the Conveyor CI Driver Runtime.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
+class InvalidRunIDException(DriverRuntimeException):
+    """Raised when the run_id is missing from the labels ."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message

--- a/conveyor/runtime/nat_connection.py
+++ b/conveyor/runtime/nat_connection.py
@@ -1,0 +1,21 @@
+import nats
+from typing import List, Union
+import logging
+
+
+#reusable wrapper for nats connection
+async def  connect_to_nats(
+    servers: Union[str, List[str]] = "nats://localhost:4222",
+    **options
+):
+    """
+    Reusable connection function. Usage:
+    nc = await connect_to_nats(["url1", "url2"], **options)
+    or
+    nc = await connect_to_nats("nats://localhost:4222", **options)
+    for more you can refer to the nats documentation. 
+    """
+    logging.info("Connecting to NATS server(s): %s", servers)
+    if isinstance(servers, str):
+        servers = [servers]
+    return await nats.connect(servers=servers, **options)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.32.4
 nats-py==2.10.0
+httpx==0.28.1


### PR DESCRIPTION
Now validates that `run_id` is present and non-empty in merged labels
    - Raises `InvalidRunIDException` (subclass of `DriverRuntimeException`) if missing
    - Prevents malformed messages from being published to NATS